### PR TITLE
Fix misleading types in Graph.edge_attrs method

### DIFF
--- a/src/graph.py
+++ b/src/graph.py
@@ -2,7 +2,8 @@ import networkx as nx
 from model import (
     Node, NodeHandle,
     NodeAttrs, Edge,
-    EdgeAttrs, GraphMapping
+    EdgeAttrs, GraphMapping,
+    EdgeEndpoints
 )
 from typing import Optional, Iterable, Any
 
@@ -59,7 +60,7 @@ class Graph:
     def node_attrs(self, node: NodeHandle) -> NodeAttrs:
         return self[node]
 
-    def edge_attrs(self, edge: Edge) -> EdgeAttrs:
+    def edge_attrs(self, edge: EdgeEndpoints) -> EdgeAttrs:
         return self._graph[edge[0]][edge[1]]['payload']
 
     def edge_for_handles(self, handle_1: NodeHandle, handle_2: NodeHandle) -> Edge:

--- a/src/model.py
+++ b/src/model.py
@@ -36,4 +36,9 @@ class Edge:
     attrs: EdgeAttrs
 
 
+class EdgeEndpoints(NamedTuple):
+    u: NodeHandle
+    v: NodeHandle
+
+
 GraphMapping = Dict[NodeHandle, NodeHandle]

--- a/src/model.py
+++ b/src/model.py
@@ -2,8 +2,15 @@ import itertools as it
 from typing import NamedTuple, Literal, Optional, Dict
 from dataclasses import dataclass, field
 
+
 NodeHandle = int
 EdgeHandle = int
+
+
+class EdgeEndpoints(NamedTuple):
+    u: NodeHandle
+    v: NodeHandle
+
 
 class NodeAttrs(NamedTuple):
     label: str
@@ -13,6 +20,7 @@ class NodeAttrs(NamedTuple):
 
     def __str__(self, i: int = None) -> str:
         return f'{i}\nl={self.label}, h={self.hanging}\nx={self.x}, y={self.y}'
+
 
 @dataclass
 class EdgeAttrs:
@@ -29,16 +37,16 @@ class Node:
     attrs: NodeAttrs
     handle: NodeHandle = field(default_factory=it.count().__next__, init=True)
 
+
 @dataclass
 class Edge:
     u: NodeHandle
     v: NodeHandle
     attrs: EdgeAttrs
 
-
-class EdgeEndpoints(NamedTuple):
-    u: NodeHandle
-    v: NodeHandle
+    def get_endpoints(self) -> EdgeEndpoints:
+        return EdgeEndpoints(u, v)
 
 
 GraphMapping = Dict[NodeHandle, NodeHandle]
+


### PR DESCRIPTION
1. Passing an `Edge` to `def edge_attrs(self, edge: Edge) -> EdgeAttrs:` does not make any sense as `Edge` already contains `EdgeAttrs`.
2. Implementation of the method assumed that passed argument is a tuple
3. In all current usages we just pass tuple of `(u, v)` as arg.