### PR TITLE
Make use of node_match & edge_match options & abstract add/remove of Q edge to separate method

### DIFF
--- a/src/__test__/test_production.py
+++ b/src/__test__/test_production.py
@@ -40,15 +40,8 @@ class TestProduction1(unittest.TestCase):
         nodes = [node_1, node_2, node_3, node_4, node_5, node_6]
 
         graph.add_node_collection(nodes)
-
-        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
-        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge_3.attrs.handle))
-        graph.add_edge(q_edge_3)
-        graph.add_edge(q_edge_4)
+        graph.add_q_hyperedge((node_1, node_2, node_5, node_6), EdgeAttrs('q', True))
+        graph.add_q_hyperedge((node_2, node_4, node_3, node_5), EdgeAttrs('q', True))
 
         graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', flag=False)))
         for node_1, node_2 in it.pairwise(nodes + [node_1]):
@@ -69,10 +62,7 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=False))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_1, node_2, node_3, node_4), EdgeAttrs('q', False))
 
         for node_a, node_b in it.pairwise(nodes + [node_1]):
             graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
@@ -91,11 +81,7 @@ class TestProduction1(unittest.TestCase):
         nodes = [node_1, node_2, node_3, node_4]
 
         graph.add_node_collection(nodes)
-
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_1, node_2, node_3, node_4), EdgeAttrs('q', True))
 
         graph.add_edge(Edge(node_4.handle, node_1.handle, EdgeAttrs(kind='q', flag=True)))
         for node_a, node_b in it.pairwise(nodes):
@@ -115,11 +101,7 @@ class TestProduction1(unittest.TestCase):
         nodes = [node_1, node_2, node_3, node_4]
 
         graph.add_node_collection(nodes)
-
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_1, node_2, node_3, node_4), EdgeAttrs('q', True))
 
         for node_a, node_b in it.pairwise(nodes + [nodes[0]]):
             graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
@@ -141,12 +123,7 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_4, node_2, node_3]
 
         graph.add_node_collection(nodes)
-
-        # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
@@ -166,12 +143,7 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_2, node_3, node_4]
 
         graph.add_node_collection(nodes)
-
-        # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
@@ -194,14 +166,8 @@ class TestProduction2(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
-        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge_3.attrs.handle))
-        graph.add_edge(q_edge_3)
-        graph.add_edge(q_edge_4)
+        graph.add_q_hyperedge((node_1, node_5, node_2, node_6), EdgeAttrs('q', True))
+        graph.add_q_hyperedge((node_2, node_4, node_3, node_5), EdgeAttrs('q', True))
 
         graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', flag=False)))
         for node_1, node_2 in it.pairwise(nodes + [node_1]):
@@ -222,12 +188,7 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_4, node_2, node_3]
 
         graph.add_node_collection(nodes)
-
-        # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=False))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', False))
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
@@ -247,12 +208,7 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_4, node_2, node_3]
 
         graph.add_node_collection(nodes)
-
-        # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='q', flag=False)))
@@ -272,12 +228,7 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_4, node_2, node_3]
 
         graph.add_node_collection(nodes)
-
-        # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
         for node_1, node_2 in it.pairwise(nodes):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
@@ -297,13 +248,9 @@ class TestProduction2(unittest.TestCase):
         nodes = [node_0, node_1, node_4, node_2, node_3]
 
         graph.add_node_collection(nodes)
+        graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
-
         for node_1, node_2 in it.pairwise(nodes):
             graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 

--- a/src/__test__/test_production.py
+++ b/src/__test__/test_production.py
@@ -19,13 +19,10 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge(nodes, EdgeAttrs('q', True))
 
         for node_a, node_b in it.pairwise(nodes + [node_1]):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
         p1 = P1()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p1.get_lhs())
@@ -44,18 +41,18 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
-        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', value=True, handle=q_edge_3.attrs.handle))
+        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge_3.attrs.handle))
         graph.add_edge(q_edge_3)
         graph.add_edge(q_edge_4)
 
-        graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', flag=False)))
         for node_1, node_2 in it.pairwise(nodes + [node_1]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p1 = P1()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p1.get_lhs())
@@ -72,13 +69,13 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=False))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=False))
+        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_a, node_b in it.pairwise(nodes + [node_1]):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
         p1 = P1()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p1.get_lhs())
@@ -95,14 +92,14 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
-        graph.add_edge(Edge(node_4.handle, node_1.handle, EdgeAttrs(kind='q', value=True)))
+        graph.add_edge(Edge(node_4.handle, node_1.handle, EdgeAttrs(kind='q', flag=True)))
         for node_a, node_b in it.pairwise(nodes):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
         p1 = P1()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p1.get_lhs())
@@ -119,13 +116,13 @@ class TestProduction1(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_a, node_b in it.pairwise(nodes + [nodes[0]]):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
         p1 = P1()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p1.get_lhs())
@@ -146,13 +143,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -171,13 +168,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -197,18 +194,18 @@ class TestProduction2(unittest.TestCase):
 
         graph.add_node_collection(nodes)
 
-        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_1.handle, node_5.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_2.handle, node_6.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
-        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', value=True, handle=q_edge_3.attrs.handle))
+        q_edge_3 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_4 = Edge(node_3.handle, node_5.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge_3.attrs.handle))
         graph.add_edge(q_edge_3)
         graph.add_edge(q_edge_4)
 
-        graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_edge(Edge(node_2.handle, node_5.handle, EdgeAttrs(kind='e', flag=False)))
         for node_1, node_2 in it.pairwise(nodes + [node_1]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -227,13 +224,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=False))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=False))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -252,13 +249,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes + [node_0]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='q', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='q', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -277,13 +274,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())
@@ -302,13 +299,13 @@ class TestProduction2(unittest.TestCase):
         graph.add_node_collection(nodes)
 
         # Add two edges of type Q
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
+        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', flag=True))
+        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', flag=True, handle=q_edge.attrs.handle))
         graph.add_edge(q_edge)
         graph.add_edge(q_edge_2)
 
         for node_1, node_2 in it.pairwise(nodes):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
         p2 = P2()
         mapping_gen = graph.generate_subgraphs_isomorphic_with(p2.get_lhs())

--- a/src/graph.py
+++ b/src/graph.py
@@ -114,6 +114,7 @@ class Graph:
 
     def add_q_hyperedge(self, nodes: tuple[Node, Node, Node, Node], edge_attrs: EdgeAttrs, q_node_handle: NodeHandle = None):
         assert len(nodes) == 4
+        assert edge_attrs.kind == 'q'
         x, y = util.avg_point_from_nodes(nodes)
         node_attrs = NodeAttrs('q', x, y, edge_attrs.flag)
         q_node = Node(node_attrs) if q_node_handle is None else Node(node_attrs, q_node_handle)

--- a/src/graph.py
+++ b/src/graph.py
@@ -82,6 +82,22 @@ class Graph:
         nx.draw_networkx(self.nx_graph, pos=positions, labels=node_labels, **kwargs)
         nx.draw_networkx_edge_labels(self.nx_graph, pos=positions, edge_labels=edge_labels, **kwargs)
 
+
+    def add_q_hyperedge(self, endpoints: tuple[EdgeEndpoints, EdgeEndpoints], attrs: EdgeAttrs):
+        """
+        :param endpoints: tuple of two EdgeEndpoints; crosswise edge pairs the Q hyper edge should connect
+        :param attrs: attributes that will be shared by all "classical edges" comprising the hyper edge
+
+        Please note that this method does not remove any lingering nodes / edges. It only adds two new edges between given endpoints
+        and ensures that all edges have common handle in their attributes.
+        """
+        assert len(endpoints) == 2, f"Q hyperedge specification expects tuple of two pairs, got: {endpoints}"
+        ep_1, ep_2 = endpoints
+        edge_1 = Edge(*ep_1, attrs)
+        edge_2 = Edge(*ep_2, attrs)
+        self.add_edge(edge_1)
+        self.add_edge(edge_2)
+
     @property
     def nx_graph(self) -> nx.Graph:
         return self._graph

--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,6 @@ def main():
 
 def test_production():
     graph = Graph()
-    nhf = graph.node_handle_factory
 
     node_1 = Node(NodeAttrs('v', 0, 0, False))
     node_2 = Node(NodeAttrs('v', 1, 0, False))

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ def main():
     graph.add_node_collection(nodes)
 
     for node_1, node_2 in it.pairwise(nodes + [node_1]):
-        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
     print(graph.nx_graph.nodes)
     print(graph.nx_graph.edges)
@@ -43,6 +43,7 @@ def main():
 
 def test_production():
     graph = Graph()
+    nhf = graph.node_handle_factory
 
     node_1 = Node(NodeAttrs('v', 0, 0, False))
     node_2 = Node(NodeAttrs('v', 1, 0, False))
@@ -53,15 +54,15 @@ def test_production():
     graph.add_node_collection(nodes)
 
     # Add two edges of type Q, note that they have the same handle!!!
-    graph.add_q_hyperedge(((node_1.handle, node_3.handle), (node_2.handle, node_4.handle)), EdgeAttrs('q', True))
+    graph.add_q_hyperedge(nodes, EdgeAttrs('q', True))
 
     for node_1, node_2 in it.pairwise(nodes + [node_1]):
-        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
     graph.display()
     plt.show()
 
-    P1()(graph)
+    assert P1()(graph)
 
 
 def test_production2():
@@ -77,19 +78,19 @@ def test_production2():
     graph.add_node_collection(nodes)
 
     # Add two edges of type Q, note that they have the same handle!!!
-    graph.add_q_hyperedge(((node_0.handle, node_2.handle), (node_1.handle, node_3.handle)), EdgeAttrs('q', True))
+    graph.add_q_hyperedge((node_0, node_1, node_2, node_3), EdgeAttrs('q', True))
 
     for node_1, node_2 in it.pairwise(nodes + [node_0]):
-        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', flag=False)))
 
     graph.display()
     plt.show()
 
-    P2()(graph)
+    assert P2()(graph)
 
 
 if __name__ == '__main__':
     plt.rcParams['figure.figsize'] = (16, 9)
-    test_production()
-    # test_production2()
+    # test_production()
+    test_production2()
     # main()

--- a/src/main.py
+++ b/src/main.py
@@ -53,16 +53,16 @@ def test_production():
     graph.add_node_collection(nodes)
 
     # Add two edges of type Q, note that they have the same handle!!!
-    q_edge = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True))
-    q_edge_2 = Edge(node_2.handle, node_4.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
-    graph.add_edge(q_edge)
-    graph.add_edge(q_edge_2)
+    graph.add_q_hyperedge(((node_1.handle, node_3.handle), (node_2.handle, node_4.handle)), EdgeAttrs('q', True))
 
     for node_1, node_2 in it.pairwise(nodes + [node_1]):
         graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
 
+    graph.display()
+    plt.show()
+
     P1()(graph)
-    # p1_instance = P1()
+
 
 def test_production2():
     graph = Graph()
@@ -77,22 +77,19 @@ def test_production2():
     graph.add_node_collection(nodes)
 
     # Add two edges of type Q, note that they have the same handle!!!
-    q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-    q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
-    graph.add_edge(q_edge)
-    graph.add_edge(q_edge_2)
+    graph.add_q_hyperedge(((node_0.handle, node_2.handle), (node_1.handle, node_3.handle)), EdgeAttrs('q', True))
 
     for node_1, node_2 in it.pairwise(nodes + [node_0]):
         graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
 
-    # graph.display()
-    # plt.show()
+    graph.display()
+    plt.show()
 
     P2()(graph)
 
 
 if __name__ == '__main__':
     plt.rcParams['figure.figsize'] = (16, 9)
-    # test_production()
-    test_production2()
+    test_production()
+    # test_production2()
     # main()

--- a/src/model.py
+++ b/src/model.py
@@ -1,5 +1,5 @@
 import itertools as it
-from typing import NamedTuple, Literal, Optional, Dict
+from typing import NamedTuple, Literal, Optional, Dict, Callable
 from dataclasses import dataclass, field
 
 
@@ -12,30 +12,43 @@ class EdgeEndpoints(NamedTuple):
     v: NodeHandle
 
 
-class NodeAttrs(NamedTuple):
-    label: str
+@dataclass
+class NodeAttrs:
+    label: Literal['v'] | Literal['q'] | Literal['p']
     x: float
     y: float
-    hanging: bool
+    flag: bool  # Interpretation of this field depends on edge kind. See presentation with project spec
 
     def __str__(self, i: int = None) -> str:
-        return f'{i}\nl={self.label}, h={self.hanging}\nx={self.x}, y={self.y}'
+        return (f'{i}, ' if i is not None else '') + f'{self.label}, {self.flag}\nx={self.x}, y={self.y}'
 
 
 @dataclass
 class EdgeAttrs:
     kind: Literal['e'] | Literal['q']
-    value: bool  # Interpretation of this field depends on edge kind. See presentation with project spec.
+    flag: bool  # Interpretation of this field depends on edge kind. See presentation with project spec.
     handle: EdgeHandle = field(default_factory=it.count().__next__, init=True)
 
     def __str__(self) -> str:
-        return f'{self.kind}, {self.value}, {self.handle}'
+        return f'{self.kind}, {self.flag}, {self.handle}'
 
 
-@dataclass
 class Node:
-    attrs: NodeAttrs
-    handle: NodeHandle = field(default_factory=it.count().__next__, init=True)
+    __slots__ = (
+        'attrs',
+        'handle'
+    )
+
+    def __init__(self, attrs: NodeAttrs, handle: NodeHandle = None, handle_factory: Callable[[], int] = None) -> None:
+        self.attrs: NodeAttrs = attrs
+        self.handle: NodeHandle = handle
+
+        if self.handle is None and handle_factory is not None:
+            self.handle = handle_factory()
+            assert self.handle is not None
+
+    def __str__(self) -> str:
+        return f'Node(attrs=NodeAttrs(l={self.attrs.label}, x={self.attrs.x}, y={self.attrs.y}, flag={self.attrs.flag}), handle={self.handle})'
 
 
 @dataclass

--- a/src/production.py
+++ b/src/production.py
@@ -279,18 +279,5 @@ class P2(Production):
         for corner_node, new_nodes in zip(corner_nodes, it.pairwise([new_border_nodes[-1]] + new_border_nodes)):
             graph.add_q_hyperedge((corner_node, *new_nodes, central_node), EdgeAttrs('q', False))
 
-        # for node_a, node_b in zip(self.external_nodes[:2], self.external_nodes[2:]):
-        #     graph.remove_edge(node_a.handle, node_b.handle)
-        #
-        # q_edge_handles = []
-        # for old_node in self.external_nodes:
-        #     edge = Edge(new_node.handle, old_node.handle, EdgeAttrs('q', False))
-        #     graph.add_edge(edge)
-        #     q_edge_handles.append(edge.attrs.handle)
-        #
-        # new_nodes[0], new_nodes[1] = new_nodes[1], new_nodes[0]
-        # for (node_a, node_b), handle in zip(it.pairwise([new_nodes[-1]] + new_nodes), q_edge_handles):
-        #     graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs('q', False, handle)))
-
         graph.display()
         plt.show()

--- a/src/production.py
+++ b/src/production.py
@@ -2,8 +2,8 @@ import itertools as it
 from copy import deepcopy
 import matplotlib.pyplot as plt
 import util
-from typing import Dict
-from model import NodeAttrs, EdgeAttrs, NodeHandle, Edge, Node
+from typing import Dict, Optional
+from model import NodeAttrs, EdgeAttrs, NodeHandle, Edge, Node, GraphMapping
 from graph import Graph
 from pprint import pprint
 from util import verify_central_hyperedges
@@ -14,12 +14,11 @@ from itertools import combinations
 class Production:
     """ Base class for all productions """
     def __init__(self) -> None:
-        pass
+        self.reset()
 
     def reset(self):
-        """ Reset state of the production so that it can be applied again.
-        Default impl does nothing."""
-        pass
+        """ Reset state of the production so that it can be applied again. """
+        self._rev_mapping = None
 
     def get_lhs(self) -> Graph:
         raise NotImplementedError("This method must be overrided in subclasses")
@@ -33,12 +32,14 @@ class Production:
         for details.
 
         :returns: bool is the production can be successfully applied, false if not"""
-        raise NotImplementedError("This method must be overrided in subclasses")
+        return True
+        # raise NotImplementedError("This method must be overrided in subclasses")
 
     def apply(self, graph: Graph) -> bool:
         self.reset()
         lhs = self.get_lhs()
         for mapping in graph.generate_subgraphs_isomorphic_with(lhs):
+            self._rev_mapping = util.reverse_dict_mapping(mapping)
             if self.is_mapping_feasible(graph, mapping):
                 self.apply_with_mapping(graph, mapping)
                 return True
@@ -62,13 +63,9 @@ class Production:
 class P1(Production):
     def __init__(self) -> None:
         self.lhs: Graph = self.__create_lhs()
-        self.rev_mapping: Dict[NodeHandle, NodeHandle] | None = None
 
     def get_lhs(self) -> Graph:
         return self.lhs
-
-    def reset(self):
-        self.rev_mapping = None
 
     def __create_lhs(self) -> Graph:
         graph = Graph()
@@ -80,94 +77,90 @@ class P1(Production):
         nodes = [node_0, node_1, node_2, node_3]
         graph.add_node_collection(nodes)
 
-        nodes.append(node_0)
 
         # Add two edges of type Q, note that they have the same handle!!!
 
-        graph.add_q_hyperedge(((node_0.handle, node_2.handle), (node_1.handle, node_3.handle)), EdgeAttrs('q', True))
+        graph.add_q_hyperedge(nodes, EdgeAttrs('q', True), 4)
+
+        nodes.append(node_0)
 
         for node_a, node_b in it.pairwise(nodes):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
-        # graph.display()
-        # plt.show()
+
+        graph.display()
+        plt.show()
 
         return graph
 
 
-    def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
-        # Now we have mapping of lhs nodes to `graph` nodes.
-        self.rev_mapping = util.reverse_dict_mapping(mapping)
-
-        # Aliasing for convenience
-        rev_mapping = self.rev_mapping
-
-        nodes = [
-            graph.node_for_handle(rev_mapping[i]) for i in range(0, len(rev_mapping))
-        ]
-
-        if any(map(lambda node: node.attrs.hanging, nodes)):
-            return False
-
-        # We still need to check whether the hyperedge in the cell centre has appropriate value,
-        if not verify_central_hyperedges(graph, nodes):
-            return False
-
-        # Also we need to verify all the edges are of appropriate type
-        for node_a, node_b in it.pairwise(nodes + [nodes[0]]):
-            edge = graph.edge_for_handles(node_a.handle, node_b.handle)
-            if edge.attrs.kind != 'e':
-                return False
-
-        return True
+    # def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
+    #     # Now we have mapping of lhs nodes to `graph` nodes.
+    #     # Aliasing for convenience
+    #     rev_mapping = self._rev_mapping
+    #
+    #     v_nodes = [
+    #         graph.node_for_handle(rev_mapping[i]) for i in range(0, len(rev_mapping) - 1)
+    #     ]
+    #     q_node = graph.node_for_handle(rev_mapping[len(rev_mapping) - 1])
+    #
+    #     if any(map(lambda node: node.attrs.flag, v_nodes)):
+    #         print('Rejecting because of bad hanging node value')
+    #         return False
+    #
+    #     # We still need to check whether the hyperedge in the cell centre has appropriate value,
+    #     if q_node.attrs.label != 'q' or q_node.attrs.flag == False:
+    #         print('Rejecting because of q', q_node)
+    #         print(rev_mapping)
+    #         return False
+    #
+    #     # Also we need to verify all the edges are of appropriate type
+    #     for node_a, node_b in it.pairwise(v_nodes + [v_nodes[0]]):
+    #         edge = graph.edge_for_handles(node_a.handle, node_b.handle)
+    #         if edge.attrs.kind != 'e':
+    #             print('Rejecting because e edge')
+    #             return False
+    #
+    #     return True
 
 
     def apply_with_mapping(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]):
         # Break the edges (1, 2), (2, 3), (3, 4), (4, 1), creating 4 new nodes
         # Add 5 new node to the center of the split
-        rev_mapping = self.rev_mapping
+        rev_mapping = self._rev_mapping
 
-        nodes = [
+        v_nodes = [
             graph.node_for_handle(rev_mapping[i]) for i in range(0, 4)
         ]
+        q_node = graph.node_for_handle(rev_mapping[4])
 
-        new_nodes = []
-        for node_a, node_b in it.pairwise(nodes + [nodes[0]]):
-            x = (node_a.attrs.x + node_b.attrs.x) / 2
-            y = (node_a.attrs.y + node_b.attrs.y) / 2
+        new_border_nodes = []
+        for node_a, node_b in it.pairwise(v_nodes + [v_nodes[0]]):
+            x, y = util.avg_point_from_nodes((node_a, node_b))
             edge_attrs = graph.edge_attrs((node_a.handle, node_b.handle))
-            h = not edge_attrs.value
-            new_node = Node(NodeAttrs('v', x, y, h))
-            new_nodes.append(new_node)
+            h = not edge_attrs.flag
+            new_node = Node(NodeAttrs('v', x, y, h)) # has no handle, will be assigned when adding to graph
+            new_border_nodes.append(new_node)
 
             graph.remove_edge(node_a.handle, node_b.handle)
             graph.add_node(new_node)
-            graph.add_edge(Edge(u=node_a.handle, v=new_node.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
-            graph.add_edge(Edge(u=new_node.handle, v=node_b.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
+            graph.add_edge(Edge(u=node_a.handle, v=new_node.handle, attrs=EdgeAttrs('e', edge_attrs.flag)))
+            graph.add_edge(Edge(u=new_node.handle, v=node_b.handle, attrs=EdgeAttrs('e', edge_attrs.flag)))
 
         # the central node
-        x = sum(map(lambda node: node.attrs.x, nodes)) / 4
-        y = sum(map(lambda node: node.attrs.y, nodes)) / 4
-        h = False
-        new_node = Node(NodeAttrs('v', x, y, h))
-        graph.add_node(new_node)
+        x, y = util.avg_point_from_nodes(v_nodes)
+        central_node = Node(NodeAttrs('v', x, y, flag=False))
+        graph.add_node(central_node)
 
-        for node in new_nodes:
-            graph.add_edge(Edge(node.handle, new_node.handle, EdgeAttrs('e', False)))
+        for node in new_border_nodes:
+            graph.add_edge(Edge(node.handle, central_node.handle, EdgeAttrs('e', False)))
 
-        # add Q edges
-        for node_a, node_b in zip(nodes[:2], nodes[2:]):
-            graph.remove_edge(node_a.handle, node_b.handle)
+        # remove old Q hyperedge
+        graph.remove_q_hyperedge(q_node.handle)
 
-        q_edge_handles = []
-        for node_a, node_b in it.pairwise([new_nodes[-1]] + new_nodes):
-            edge = Edge(node_a.handle, node_b.handle, EdgeAttrs('q', False))
-            graph.add_edge(edge)
-            q_edge_handles.append(edge.attrs.handle)
-
-
-        for old_node, edge_handle in zip(nodes, q_edge_handles):
-            graph.add_edge(Edge(new_node.handle, old_node.handle, EdgeAttrs('q', False, edge_handle)))
+        # add four new Q hyperedges
+        for corner_node, new_nodes in zip(v_nodes, it.pairwise([new_border_nodes[-1]] + new_border_nodes)):
+            graph.add_q_hyperedge((corner_node, *new_nodes, central_node), EdgeAttrs('q', False))
 
         graph.display()
         plt.show()
@@ -176,15 +169,11 @@ class P1(Production):
 class P2(Production):
     def __init__(self) -> None:
         self.lhs: Graph = self.__create_lhs()
-        self.rev_mapping: Dict[NodeHandle, NodeHandle] | None = None
         self.hanging_node: Node | None = None
         self.external_nodes: list[Node] | None = None
 
     def get_lhs(self) -> Graph:
         return self.lhs
-
-    def reset(self):
-        self.rev_mapping = None
 
     def __create_lhs(self) -> Graph:
         graph = Graph()
@@ -195,113 +184,113 @@ class P2(Production):
         node_3 = Node(NodeAttrs('v', 0, 1, False), 3)
         node_4 = Node(NodeAttrs('v', 1, 0.5, True), 4)
         nodes = [node_0, node_1, node_4, node_2, node_3]
+        corner_nodes = (node_0, node_1, node_2, node_3)
 
         graph.add_node_collection(nodes)
 
-        # Add two edges of type Q, note that they have the same handle!!!
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
+        graph.add_q_hyperedge(corner_nodes, EdgeAttrs('q', True), 5)
 
-        for node_1, node_2 in it.pairwise(nodes + [node_0]):
-            graph.add_edge(Edge(node_1.handle, node_2.handle, EdgeAttrs(kind='e', value=False)))
+        for node_a, node_b in it.pairwise(nodes + [node_0]):
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
         # graph.display()
         # plt.show()
 
         return graph
 
-    def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
-        # Now we have mapping of lhs nodes to `graph` nodes.
-        self.rev_mapping = util.reverse_dict_mapping(mapping)
-
-        # Aliasing for convenience
-        rev_mapping = self.rev_mapping
-
-        nodes = [
-            graph.node_for_handle(rev_mapping[i]) for i in (0, 1, 4, 2, 3, 0)
-        ]
-
-        # check if appropriate vertex in the middle of the edge is hanging
-        if not nodes[2].attrs.hanging:
-            return False
-        for i in (0, 1, 3, 4):
-            if nodes[i].attrs.hanging:
-                return False
-
-        self.hanging_node = nodes[2]
-        external_nodes = deepcopy(nodes[:-1])
-        external_nodes.remove(self.hanging_node)
-        self.external_nodes = external_nodes
-
-        # Check whether the hyperedge in the cell centre has appropriate value
-        if not verify_central_hyperedges(graph, nodes=self.external_nodes):
-            return False
-
-        # Verify all the edges are of appropriate type
-        for node_a, node_b in it.pairwise(nodes):
-            edge = graph.edge_for_handles(node_a.handle, node_b.handle)
-            if edge.attrs.kind != 'e':
-                return False
-
-        return True
+    # def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
+    #     # Now we have mapping of lhs nodes to `graph` nodes.
+    #
+    #     # Aliasing for convenience
+    #     rev_mapping = self._rev_mapping
+    #
+    #     nodes = [
+    #         graph.node_for_handle(rev_mapping[i]) for i in (0, 1, 4, 2, 3, 0)
+    #     ]
+    #
+    #     # check if appropriate vertex in the middle of the edge is hanging
+    #     if not nodes[2].attrs.flag:
+    #         return False
+    #     for i in (0, 1, 3, 4):
+    #         if nodes[i].attrs.flag:
+    #             return False
+    #
+    #     self.hanging_node = nodes[2]
+    #     external_nodes = deepcopy(nodes[:-1])
+    #     external_nodes.remove(self.hanging_node)
+    #     self.external_nodes = external_nodes
+    #
+    #     # Check whether the hyperedge in the cell centre has appropriate value
+    #     if not verify_central_hyperedges(graph, nodes=self.external_nodes):
+    #         return False
+    #
+    #     # Verify all the edges are of appropriate type
+    #     for node_a, node_b in it.pairwise(nodes):
+    #         edge = graph.edge_for_handles(node_a.handle, node_b.handle)
+    #         if edge.attrs.kind != 'e':
+    #             return False
+    #
+    #     return True
 
     def apply_with_mapping(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]):
-        rev_mapping = self.rev_mapping
-        nodes = [
+        rev_mapping = self._rev_mapping
+
+        # counter-clock-wise
+        in_order_nodes = [graph.node_for_handle(rev_mapping[i]) for i in (0, 1, 2, 3, 4, 5)]
+        corner_nodes = [node for node in in_order_nodes[:-2]]
+        v_nodes = [
             graph.node_for_handle(rev_mapping[i]) for i in (0, 1, 4, 2, 3, 0)
         ]
+        hanging_node = graph.node_for_handle(rev_mapping[4])
+        q_node = graph.node_for_handle(rev_mapping[5])
 
         # change hanging value of hanging node
-        replaced_hanging_node = Node(NodeAttrs('v', self.hanging_node.attrs.x, self.hanging_node.attrs.y, False))
-        graph.add_node(replaced_hanging_node)
+        # we actualy have reference to this node, so we can modify it in place
+        hanging_node.attrs.flag = False
 
-        new_nodes = [replaced_hanging_node]
-        for node_a, node_b in it.pairwise(nodes):
+        new_border_nodes = []
+        for node_a, node_b in ((in_order_nodes[0], in_order_nodes[1]), (in_order_nodes[2], in_order_nodes[3]), (in_order_nodes[3], in_order_nodes[0])):
+            x, y = util.avg_point_from_nodes((node_a, node_b))
             edge_attrs = graph.edge_attrs((node_a.handle, node_b.handle))
-            if node_a.attrs.hanging:
-                graph.add_edge(Edge(u=replaced_hanging_node.handle, v=node_b.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
-            elif node_b.attrs.hanging:
-                graph.add_edge(Edge(u=node_a.handle, v=replaced_hanging_node.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
-            else:
-                x = (node_a.attrs.x + node_b.attrs.x) / 2
-                y = (node_a.attrs.y + node_b.attrs.y) / 2
-                h = not edge_attrs.value
-                new_node = Node(NodeAttrs('v', x, y, h))
-                new_nodes.append(new_node)
+            h = not edge_attrs.flag
+            new_node = Node(NodeAttrs('v', x, y, h)) # has no handle, will be assigned when adding to graph
+            new_border_nodes.append(new_node)
 
-                graph.remove_edge(node_a.handle, node_b.handle)
-                graph.add_node(new_node)
-                graph.add_edge(Edge(u=node_a.handle, v=new_node.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
-                graph.add_edge(Edge(u=new_node.handle, v=node_b.handle, attrs=EdgeAttrs('e', edge_attrs.value)))
-
-        # remove left hanging node
-        graph.remove_node(self.hanging_node.handle)
+            graph.remove_edge(node_a.handle, node_b.handle)
+            graph.add_node(new_node)
+            graph.add_edge(Edge(u=node_a.handle, v=new_node.handle, attrs=EdgeAttrs('e', edge_attrs.flag)))
+            graph.add_edge(Edge(u=new_node.handle, v=node_b.handle, attrs=EdgeAttrs('e', edge_attrs.flag)))
 
         # the central node
-        x = sum(map(lambda node: node.attrs.x, self.external_nodes)) / 4
-        y = sum(map(lambda node: node.attrs.y, self.external_nodes)) / 4
-        h = False
-        new_node = Node(NodeAttrs('v', x, y, h))
-        graph.add_node(new_node)
+        # the central node
+        x, y = util.avg_point_from_nodes(corner_nodes)
+        central_node = Node(NodeAttrs('v', x, y, flag=False))
+        graph.add_node(central_node)
 
-        for node in new_nodes:
-            graph.add_edge(Edge(node.handle, new_node.handle, EdgeAttrs('e', False)))
+        for node in new_border_nodes + [hanging_node]:
+            graph.add_edge(Edge(node.handle, central_node.handle, EdgeAttrs('e', False)))
+
+        graph.remove_q_hyperedge(q_node.handle)
 
         # # add Q edges
-        for node_a, node_b in zip(self.external_nodes[:2], self.external_nodes[2:]):
-            graph.remove_edge(node_a.handle, node_b.handle)
+        assert len(new_border_nodes) == 3
+        new_border_nodes.insert(1, hanging_node)
 
-        q_edge_handles = []
-        for old_node in self.external_nodes:
-            edge = Edge(new_node.handle, old_node.handle, EdgeAttrs('q', False))
-            graph.add_edge(edge)
-            q_edge_handles.append(edge.attrs.handle)
+        for corner_node, new_nodes in zip(corner_nodes, it.pairwise([new_border_nodes[-1]] + new_border_nodes)):
+            graph.add_q_hyperedge((corner_node, *new_nodes, central_node), EdgeAttrs('q', False))
 
-        new_nodes[0], new_nodes[1] = new_nodes[1], new_nodes[0]
-        for (node_a, node_b), handle in zip(it.pairwise([new_nodes[-1]] + new_nodes), q_edge_handles):
-            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs('q', False, handle)))
+        # for node_a, node_b in zip(self.external_nodes[:2], self.external_nodes[2:]):
+        #     graph.remove_edge(node_a.handle, node_b.handle)
+        #
+        # q_edge_handles = []
+        # for old_node in self.external_nodes:
+        #     edge = Edge(new_node.handle, old_node.handle, EdgeAttrs('q', False))
+        #     graph.add_edge(edge)
+        #     q_edge_handles.append(edge.attrs.handle)
+        #
+        # new_nodes[0], new_nodes[1] = new_nodes[1], new_nodes[0]
+        # for (node_a, node_b), handle in zip(it.pairwise([new_nodes[-1]] + new_nodes), q_edge_handles):
+        #     graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs('q', False, handle)))
 
         graph.display()
         plt.show()

--- a/src/production.py
+++ b/src/production.py
@@ -87,9 +87,8 @@ class P1(Production):
         for node_a, node_b in it.pairwise(nodes):
             graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', flag=False)))
 
-
-        graph.display()
-        plt.show()
+        # graph.display()
+        # plt.show()
 
         return graph
 
@@ -162,8 +161,8 @@ class P1(Production):
         for corner_node, new_nodes in zip(v_nodes, it.pairwise([new_border_nodes[-1]] + new_border_nodes)):
             graph.add_q_hyperedge((corner_node, *new_nodes, central_node), EdgeAttrs('q', False))
 
-        graph.display()
-        plt.show()
+        # graph.display()
+        # plt.show()
 
 
 class P2(Production):
@@ -279,5 +278,5 @@ class P2(Production):
         for corner_node, new_nodes in zip(corner_nodes, it.pairwise([new_border_nodes[-1]] + new_border_nodes)):
             graph.add_q_hyperedge((corner_node, *new_nodes, central_node), EdgeAttrs('q', False))
 
-        graph.display()
-        plt.show()
+        # graph.display()
+        # plt.show()

--- a/src/production.py
+++ b/src/production.py
@@ -83,13 +83,11 @@ class P1(Production):
         nodes.append(node_0)
 
         # Add two edges of type Q, note that they have the same handle!!!
-        q_edge = Edge(node_0.handle, node_2.handle, EdgeAttrs(kind='q', value=True))
-        q_edge_2 = Edge(node_1.handle, node_3.handle, EdgeAttrs(kind='q', value=True, handle=q_edge.attrs.handle))
-        graph.add_edge(q_edge)
-        graph.add_edge(q_edge_2)
 
-        for node_0, node_1 in it.pairwise(nodes):
-            graph.add_edge(Edge(node_0.handle, node_1.handle, EdgeAttrs(kind='e', value=False)))
+        graph.add_q_hyperedge(((node_0.handle, node_2.handle), (node_1.handle, node_3.handle)), EdgeAttrs('q', True))
+
+        for node_a, node_b in it.pairwise(nodes):
+            graph.add_edge(Edge(node_a.handle, node_b.handle, EdgeAttrs(kind='e', value=False)))
 
         # graph.display()
         # plt.show()

--- a/src/production.py
+++ b/src/production.py
@@ -92,37 +92,6 @@ class P1(Production):
 
         return graph
 
-
-    # def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
-    #     # Now we have mapping of lhs nodes to `graph` nodes.
-    #     # Aliasing for convenience
-    #     rev_mapping = self._rev_mapping
-    #
-    #     v_nodes = [
-    #         graph.node_for_handle(rev_mapping[i]) for i in range(0, len(rev_mapping) - 1)
-    #     ]
-    #     q_node = graph.node_for_handle(rev_mapping[len(rev_mapping) - 1])
-    #
-    #     if any(map(lambda node: node.attrs.flag, v_nodes)):
-    #         print('Rejecting because of bad hanging node value')
-    #         return False
-    #
-    #     # We still need to check whether the hyperedge in the cell centre has appropriate value,
-    #     if q_node.attrs.label != 'q' or q_node.attrs.flag == False:
-    #         print('Rejecting because of q', q_node)
-    #         print(rev_mapping)
-    #         return False
-    #
-    #     # Also we need to verify all the edges are of appropriate type
-    #     for node_a, node_b in it.pairwise(v_nodes + [v_nodes[0]]):
-    #         edge = graph.edge_for_handles(node_a.handle, node_b.handle)
-    #         if edge.attrs.kind != 'e':
-    #             print('Rejecting because e edge')
-    #             return False
-    #
-    #     return True
-
-
     def apply_with_mapping(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]):
         # Break the edges (1, 2), (2, 3), (3, 4), (4, 1), creating 4 new nodes
         # Add 5 new node to the center of the split
@@ -196,40 +165,6 @@ class P2(Production):
         # plt.show()
 
         return graph
-
-    # def is_mapping_feasible(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]) -> bool:
-    #     # Now we have mapping of lhs nodes to `graph` nodes.
-    #
-    #     # Aliasing for convenience
-    #     rev_mapping = self._rev_mapping
-    #
-    #     nodes = [
-    #         graph.node_for_handle(rev_mapping[i]) for i in (0, 1, 4, 2, 3, 0)
-    #     ]
-    #
-    #     # check if appropriate vertex in the middle of the edge is hanging
-    #     if not nodes[2].attrs.flag:
-    #         return False
-    #     for i in (0, 1, 3, 4):
-    #         if nodes[i].attrs.flag:
-    #             return False
-    #
-    #     self.hanging_node = nodes[2]
-    #     external_nodes = deepcopy(nodes[:-1])
-    #     external_nodes.remove(self.hanging_node)
-    #     self.external_nodes = external_nodes
-    #
-    #     # Check whether the hyperedge in the cell centre has appropriate value
-    #     if not verify_central_hyperedges(graph, nodes=self.external_nodes):
-    #         return False
-    #
-    #     # Verify all the edges are of appropriate type
-    #     for node_a, node_b in it.pairwise(nodes):
-    #         edge = graph.edge_for_handles(node_a.handle, node_b.handle)
-    #         if edge.attrs.kind != 'e':
-    #             return False
-    #
-    #     return True
 
     def apply_with_mapping(self, graph: Graph, mapping: Dict[NodeHandle, NodeHandle]):
         rev_mapping = self._rev_mapping

--- a/src/util.py
+++ b/src/util.py
@@ -1,7 +1,6 @@
-from typing import Dict
+from typing import Dict, Iterable
 import itertools as it
 from model import Node
-from graph import Graph
 
 
 def reverse_dict_mapping(dictionary: Dict[int, int]) -> Dict[int, int]:
@@ -21,4 +20,18 @@ def verify_central_hyperedges(graph: 'Graph', nodes: list[Node]):
         return False
 
     return True
+
+# TODO: Type this properly
+def iter_batched(iterable: Iterable, n: int):
+    assert n >= 1
+    iterator = iter(iterable)
+    while batch := tuple(it.islice(iterator, n)):
+        yield batch
+
+
+def avg_point_from_nodes(nodes: Iterable[Node]) -> tuple[float, float]:
+    count = len(nodes)
+    x = sum(map(lambda node: node.attrs.x, nodes)) / count
+    y = sum(map(lambda node: node.attrs.y, nodes)) / count
+    return (x, y)
 


### PR DESCRIPTION
I believe I've made it so implementing `is_matching_feasible` method is not necessary now, as all mappings returned from `GraphMatcher` (from `NetworkX`) should be feasible.

I'm still leaving possibility to overload that method in case above is not true or you need some stronger guarantees in your production than simply label (kind) & flag value match.

Also added method for adding/removing q-edge (which is now represented by separate node & four edges, not only two edges). You might need similar method for P-edge, but this is a good place to start. 