### PR TITLE
graph.py,model.py: Fixups regarding p edge

### DIFF
--- a/src/graph.py
+++ b/src/graph.py
@@ -145,12 +145,12 @@ class Graph:
         :param nodes: tuple/list of FIVE nodes, that the P-hyperedge should connect; ORDER OF THE NODES MATTERS FOR THE LAYOUT, see below
         :param edge_attrs: shared attributes for all the edges that the hyperedge is comprised of
         :param p_node_handle: optional node handle for the P-hypernode; if not specified an graph-unique id will be assigned automatically
-        :param p_node_coords: optional tuple with coordinates for the P-hypernode; if not specified the position will be calculated as mean point between: nodes[0], nodes[1], nodes[3], nodes[4]
+        :param p_node_coords: optional tuple with coordinates for the P-hypernode; if not specified the position will be calculated as mean point between: nodes[0], nodes[1], nodes[2], nodes[3], nodes[4]
         """
 
         assert len(nodes) == 5
         assert edge_attrs.kind == 'p'
-        x, y = p_node_coords if p_node_coords is not None else util.avg_point_from_nodes((nodes[0], nodes[1], nodes[3], nodes[4]))
+        x, y = p_node_coords if p_node_coords is not None else util.avg_point_from_nodes(nodes)
         node_attrs = NodeAttrs('p', x, y, edge_attrs.flag)
         p_node = Node(node_attrs, handle=p_node_handle)
         self.add_node(p_node)

--- a/src/model.py
+++ b/src/model.py
@@ -25,7 +25,7 @@ class NodeAttrs:
 
 @dataclass
 class EdgeAttrs:
-    kind: Literal['e'] | Literal['q']
+    kind: Literal['e'] | Literal['q'] | Literal['p']
     flag: bool  # Interpretation of this field depends on edge kind. See presentation with project spec.
     handle: EdgeHandle = field(default_factory=it.count().__next__, init=True)
 


### PR DESCRIPTION
Add support for p label in model.py.

Resulting point from add_p_hyperedge behaves strangely because it takes into account only 4 instead of 5 nodes, thus the central node is weird-placed. Fix it by considering all 5 nodes.