### PR TITLE
graph.py: Fix the edge_equality

### DIFF
--- a/src/graph.py
+++ b/src/graph.py
@@ -19,14 +19,12 @@ def node_equality(nx_node_attrs_1, nx_node_attrs_2) -> bool:
         attrs_1.flag == attrs_2.flag
     )
 
-
 def edge_equality(nx_edge_attrs_1, nx_edge_attrs_2) -> bool:
     attrs_1: EdgeAttrs = nx_edge_attrs_1['payload']
     attrs_2: EdgeAttrs = nx_edge_attrs_2['payload']
 
     return (
-        attrs_1.kind == attrs_2.kind and
-        attrs_2.flag == attrs_2.flag
+        attrs_1.kind == attrs_2.kind
     )
 
 


### PR DESCRIPTION
Matching edges exactly with flag attributes causes problems with border. Suppose we have split the square grid many times and one square lies partly on the border. Then the productions which we have won't catch it because flag value differs from lhs. So in order to catch these situations we would have to explicitly introduce 4 new productions (1 border, 2 borders etc) in case of squares and in case of pentagons it's even more.

Since all relevant information is stored in vertices, after matching nodes exactly we don't have to match edges exactly; that's why we fix it by removing second condition.