### PR TITLE
production/production_16: Fix edges' R flag after P16

### DIFF
--- a/src/production/production_16.py
+++ b/src/production/production_16.py
@@ -43,5 +43,9 @@ class P16(Production):
         # get inner node, the hyperedge
         node_p = graph.node_for_handle(rev_mapping[5])
     
-        node_p.attrs.flag = True
+        x = node_p.attrs.x
+        y = node_p.attrs.y
+        graph.remove_p_hyperedge(node_p.handle)
+        edge_attrs = EdgeAttrs('p', True)
+        graph.add_p_hyperedge(vertices, edge_attrs, node_p.handle, (x,y))
 


### PR DESCRIPTION
After application of virtual adaptation (P16) node-P's flag has been correctly changed, but the flag value of outcoming P edges hasn't been set to True. Fix it by removing old P node and adding new one with correct flag.