### PR TITLE
production/production_10: Change attr instead of deletion

### DIFF
--- a/src/production/production_10.py
+++ b/src/production/production_10.py
@@ -44,20 +44,14 @@ class P10(Production):
         # you must get edges attrs before you remove, now it is relevant
         edge = vertices[0].handle, node_h.handle
         is_boundary = graph.edge_attrs(edge).flag
-        graph.remove_node(node_h.handle)
-        edge = vertices[0].handle, vertices[1].handle
-        # only flag value is important, because it will propagate through split
-        tmp_edge = Edge(edge[0], edge[1],  EdgeAttrs('e', is_boundary, -1))
-        graph.add_edge(tmp_edge)
-        # change hanging atribute of the node
-        hang = graph.split_edge_with_vnode(edge, node_flag=False, node_handle=node_h.handle)
+        node_h.attrs.flag = False
 
         # skip first pair because it already exists
         idx_nodes = [1, 4, 2, 3, 0]
         nodes_shuffled = [vertices[idx] for idx in idx_nodes]
 
         # hanging node is already created, should be on boundry list
-        new_boundary = [hang]
+        new_boundary = [node_h]
         for node_a, node_b in it.pairwise(nodes_shuffled):
             edge = (node_a.handle, node_b.handle)
             edge_attrs = graph.edge_attrs(edge)


### PR DESCRIPTION
Currently, the hanging node is temporarly deleted. This causes incorrect behaviour when there were another edges connected to the hanging node - they are deleted permamently. Change the node's flag instead of removing and adding the hanging node.


co-authored-by: Maciej Skoczeń